### PR TITLE
Update README and add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-пока нечего сказать
+# TeploED
+
+A simple greenhouse management UI. The project provides a basic interface for controlling and monitoring greenhouse parameters through a web page.
+
+## Setup and Running
+
+1. Clone or download this repository.
+2. Open `greenhouse.html` in any modern web browser.
+
+No additional dependencies or prerequisites are required.
+
+## License
+
+This project is licensed under the [MIT License](LICENSE). In short, you may use, modify, and distribute the code freely, as long as you include the copyright notice and license text.


### PR DESCRIPTION
## Summary
- add MIT license
- document greenhouse management UI in README
- add usage instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68407ae415848330a21259c8eb3af2db